### PR TITLE
Make ClawIn/Outputs and ElevatorIn/Outputs fields public

### DIFF
--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 55;
-  public static final String GIT_SHA = "09aafdb8016cc629e0daebca2bb28702dcb62ea7";
-  public static final String GIT_DATE = "2025-02-03 18:32:50 EST";
-  public static final String GIT_BRANCH = "landing-zone-alignment";
-  public static final String BUILD_DATE = "2025-02-03 19:20:28 EST";
-  public static final long BUILD_UNIX_TIME = 1738628428795L;
+  public static final int GIT_REVISION = 18;
+  public static final String GIT_SHA = "68678ee8f872b701c88c825bca64cbfb12edde36";
+  public static final String GIT_DATE = "2025-02-03 19:26:05 EST";
+  public static final String GIT_BRANCH = "68-public-elevatorIOs";
+  public static final String BUILD_DATE = "2025-02-04 08:56:30 EST";
+  public static final long BUILD_UNIX_TIME = 1738677390521L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/subsystems/scoring/ClawIO.java
+++ b/src/main/java/frc/robot/subsystems/scoring/ClawIO.java
@@ -20,24 +20,24 @@ public interface ClawIO {
      * <p>This is left intentionally vague until we decide on CANrange vs. beam break vs. something
      * else
      */
-    boolean coralDetected = false;
+    public boolean coralDetected = false;
 
     /** Whether or not the sensor detects an algae */
-    boolean algaeDetected = false;
+    public boolean algaeDetected = false;
 
-    MutAngle clawMotorPos = Rotations.mutable(0.0);
+    public MutAngle clawMotorPos = Rotations.mutable(0.0);
 
     /* Supply current of the claw motor */
-    MutCurrent clawSupplyCurrent = Amps.mutable(0.0);
+    public MutCurrent clawSupplyCurrent = Amps.mutable(0.0);
 
     /* Stator current of the claw motor */
-    MutCurrent clawStatorCurrent = Amps.mutable(0.0);
+    public MutCurrent clawStatorCurrent = Amps.mutable(0.0);
   }
 
   @AutoLog
   public static class ClawOutputs {
     /** The voltage applied to the claw motor */
-    MutVoltage clawAppliedVolts = Volts.mutable(0.0);
+    public MutVoltage clawAppliedVolts = Volts.mutable(0.0);
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/scoring/ElevatorIO.java
+++ b/src/main/java/frc/robot/subsystems/scoring/ElevatorIO.java
@@ -23,58 +23,58 @@ public interface ElevatorIO {
   @AutoLog
   public static class ElevatorInputs {
     /** The angle of the 19 tooth-gear-encoder. Counts total rotations, not absolute position. */
-    MutAngle largeEncoderPos = Rotations.mutable(0.0);
+    public MutAngle largeEncoderPos = Rotations.mutable(0.0);
 
     /** The angle of the 17 tooth-gear-encoder. Counts total rotations, not absolute position. */
-    MutAngle smallEncoderPos = Rotations.mutable(0.0);
+    public MutAngle smallEncoderPos = Rotations.mutable(0.0);
 
-    /** Absolute position of the 19 tooth-gear-encocer. Wraps around after 1 rotation */
-    MutAngle largeEncoderAbsolutePos = Rotations.mutable(0.0);
+    /** Absolute position of the 19 tooth-gear-encoder. Wraps around after 1 rotation */
+    public MutAngle largeEncoderAbsolutePos = Rotations.mutable(0.0);
 
-    /** Absolute position of the 17 tooth-gear-encocer. Wraps around after 1 rotation */
-    MutAngle smallEncoderAbsolutePos = Rotations.mutable(0.0);
+    /** Absolute position of the 17 tooth-gear-encoder. Wraps around after 1 rotation */
+    public MutAngle smallEncoderAbsolutePos = Rotations.mutable(0.0);
 
     /** Goal position of the elevator */
-    MutAngle largeEncoderGoalPos = Rotations.mutable(0.0);
+    public MutAngle largeEncoderGoalPos = Rotations.mutable(0.0);
 
     /** Profile setpoint goal position of the elevator */
-    MutAngle largeEncoderSetpointPos = Rotations.mutable(0.0);
+    public MutAngle largeEncoderSetpointPos = Rotations.mutable(0.0);
 
     /** Stator current of the lead elevator motor */
-    MutCurrent elevatorLeadMotorStatorCurrent = Amps.mutable(0.0);
+    public MutCurrent elevatorLeadMotorStatorCurrent = Amps.mutable(0.0);
 
     /** Supply current of the lead elevator motor */
-    MutCurrent elevatorLeadMotorSupplyCurrent = Amps.mutable(0.0);
+    public MutCurrent elevatorLeadMotorSupplyCurrent = Amps.mutable(0.0);
 
     /** Stator current of the follower elevator motor */
-    MutCurrent elevatorFollowerMotorStatorCurrent = Amps.mutable(0.0);
+    public MutCurrent elevatorFollowerMotorStatorCurrent = Amps.mutable(0.0);
 
     /** Supply current of the follower elevator motor */
-    MutCurrent elevatorFollowerMotorSupplyCurrent = Amps.mutable(0.0);
+    public MutCurrent elevatorFollowerMotorSupplyCurrent = Amps.mutable(0.0);
 
     /**
      * Current closed-loop error (distance from setpoint position) as reported by the lead motor
      * TalonFX, in rotations.
      */
-    double motionMagicError = 0.0;
+    public double motionMagicError = 0.0;
 
     /** Velocity of the mechanism, as reported by the lead motor TalonFX */
-    MutAngularVelocity elevatorMechanismVelocity = RotationsPerSecond.mutable(0.0);
+    public MutAngularVelocity elevatorMechanismVelocity = RotationsPerSecond.mutable(0.0);
   }
 
   @AutoLog
   public static class ElevatorOutputs {
     /** The voltage applied to the elevator motor */
-    MutVoltage elevatorAppliedVolts = Volts.mutable(0.0);
+    public MutVoltage elevatorAppliedVolts = Volts.mutable(0.0);
 
     /** Contribution of the p-term to motor output */
-    MutVoltage pContrib = Volts.mutable(0.0);
+    public MutVoltage pContrib = Volts.mutable(0.0);
 
     /** Contribution of the i-term to motor output */
-    MutVoltage iContrib = Volts.mutable(0.0);
+    public MutVoltage iContrib = Volts.mutable(0.0);
 
-    /** Contribution of the d-term to motor outdut */
-    MutVoltage dContrib = Volts.mutable(0.0);
+    /** Contribution of the d-term to motor output */
+    public MutVoltage dContrib = Volts.mutable(0.0);
   }
 
   /**


### PR DESCRIPTION
Make the fields of ClawInputs, ClawOutputs, ElevatorInputs, & ElevatorOutputs public to prevent "Build failed" and also to remove some of the huge number of "problems" detected by VSCode in the project.

Also fixes some typos in docstrings (encocer -> encoder & outdut -> output)