### PR TITLE
Rename wrist tuning mode and variables to use Voltage Control

### DIFF
--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 42;
-  public static final String GIT_SHA = "e5430ae52626ab333174175a164b141a843b1843";
-  public static final String GIT_DATE = "2025-02-12 17:34:36 EST";
-  public static final String GIT_BRANCH = "41-add-wrist";
-  public static final String BUILD_DATE = "2025-02-12 18:00:41 EST";
-  public static final long BUILD_UNIX_TIME = 1739401241525L;
+  public static final int GIT_REVISION = 24;
+  public static final String GIT_SHA = "33f2670bd8d4c16bbc7ccf9abc8dcd675d5be0c9";
+  public static final String GIT_DATE = "2025-02-12 19:12:16 EST";
+  public static final String GIT_BRANCH = "85-wrist-voltage-control";
+  public static final String BUILD_DATE = "2025-02-13 10:03:54 EST";
+  public static final long BUILD_UNIX_TIME = 1739459034804L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/TestModeManager.java
+++ b/src/main/java/frc/robot/TestModeManager.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 public class TestModeManager {
   public enum TestMode {
     ElevatorTuning,
-    WristCurrentTuning,
+    WristVoltageTuning,
     WristClosedLoopTuning,
     ClawTuning,
     ClawOvershootTuning,
@@ -35,7 +35,7 @@ public class TestModeManager {
     testModeChooser.setDefaultOption("None", TestMode.None);
     // Elevator Test Modes
     testModeChooser.addOption("Elevator Tuning", TestMode.ElevatorTuning);
-    testModeChooser.addOption("Wrist Current Tuning", TestMode.WristCurrentTuning);
+    testModeChooser.addOption("Wrist Voltage Tuning", TestMode.WristVoltageTuning);
     testModeChooser.addOption("Wrist Closed-Loop Tuning", TestMode.WristClosedLoopTuning);
     testModeChooser.addOption("Claw Tuning", TestMode.ClawTuning);
     // Drive Test Modes

--- a/src/main/java/frc/robot/subsystems/scoring/WristIO.java
+++ b/src/main/java/frc/robot/subsystems/scoring/WristIO.java
@@ -10,11 +10,11 @@ import edu.wpi.first.units.AngularVelocityUnit;
 import edu.wpi.first.units.VoltageUnit;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.MutAngle;
 import edu.wpi.first.units.measure.MutAngularVelocity;
 import edu.wpi.first.units.measure.MutCurrent;
 import edu.wpi.first.units.measure.Per;
+import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
 public interface WristIO {
@@ -110,12 +110,13 @@ public interface WristIO {
   public default void setOverrideMode(boolean override) {}
 
   /**
-   * Set the current to apply in override mode.
+   * Set the voltage to apply in override mode.
    *
-   * <p>This is a current because the wrist uses TorqueCurrentFOC for control instead of voltage.
+   * <p>This is a voltage because the wrist uses MotionMagicExpoVoltage for control instead of
+   * torque-current FOC
    *
-   * @param current The current to apply. This will only be applied after setOverrideMode(true) is
+   * @param voltage The voltage to apply. This will only be applied after setOverrideMode(true) is
    *     called.
    */
-  public default void setOverrideCurrent(Current current) {}
+  public default void setOverrideVoltage(Voltage voltage) {}
 }

--- a/src/main/java/frc/robot/subsystems/scoring/WristIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/scoring/WristIOTalonFX.java
@@ -1,7 +1,7 @@
 package frc.robot.subsystems.scoring;
 
-import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
@@ -13,7 +13,6 @@ import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.configs.TorqueCurrentConfigs;
 import com.ctre.phoenix6.controls.MotionMagicExpoVoltage;
-import com.ctre.phoenix6.controls.TorqueCurrentFOC;
 import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -25,10 +24,10 @@ import edu.wpi.first.units.AngularVelocityUnit;
 import edu.wpi.first.units.VoltageUnit;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.MutAngle;
-import edu.wpi.first.units.measure.MutCurrent;
+import edu.wpi.first.units.measure.MutVoltage;
 import edu.wpi.first.units.measure.Per;
+import edu.wpi.first.units.measure.Voltage;
 import frc.robot.constants.JsonConstants;
 
 public class WristIOTalonFX implements WristIO {
@@ -41,12 +40,14 @@ public class WristIOTalonFX implements WristIO {
 
   private MutAngle wristGoalPosition = Rotations.mutable(0.2);
 
-  private MotionMagicExpoVoltage request = new MotionMagicExpoVoltage(wristGoalPosition);
+  private MotionMagicExpoVoltage request =
+      new MotionMagicExpoVoltage(wristGoalPosition).withEnableFOC(true);
+  private VoltageOut overrideRequest = new VoltageOut(0.0);
 
   private boolean motorsDisabled = false;
 
   private boolean isOverriding = false;
-  private MutCurrent overrideCurrent = Amps.mutable(0.0);
+  private MutVoltage overrideVoltage = Volts.mutable(0.0);
 
   public WristIOTalonFX() {
     talonFXConfigs =
@@ -124,8 +125,8 @@ public class WristIOTalonFX implements WristIO {
 
       return;
     } else if (isOverriding) {
-      wristMotor.setControl(new TorqueCurrentFOC(overrideCurrent));
-      outputs.wristOutput = overrideCurrent.in(Amps);
+      wristMotor.setControl(overrideRequest.withOutput(overrideVoltage));
+      outputs.wristOutput = overrideVoltage.in(Volts);
 
       return;
     }
@@ -192,7 +193,7 @@ public class WristIOTalonFX implements WristIO {
     isOverriding = override;
   }
 
-  public void setOverrideCurrent(Current current) {
-    overrideCurrent.mut_replace(current);
+  public void setOverrideVoltage(Voltage volts) {
+    overrideVoltage.mut_replace(volts);
   }
 }

--- a/src/main/java/frc/robot/subsystems/scoring/WristMechanism.java
+++ b/src/main/java/frc/robot/subsystems/scoring/WristMechanism.java
@@ -1,9 +1,9 @@
 package frc.robot.subsystems.scoring;
 
-import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.Volts;
 import static edu.wpi.first.units.Units.VoltsPerRadianPerSecond;
 import static edu.wpi.first.units.Units.VoltsPerRadianPerSecondSquared;
 
@@ -19,7 +19,7 @@ import org.littletonrobotics.junction.Logger;
  * A Mechanism to keep track of the Wrist
  *
  * <ul>
- *   <li>Uses closed-loop control, using torque-current FOC
+ *   <li>Uses closed-loop voltage control
  *   <li>Tracks its own position (0 is when the center of mass is at the same height as the joint,
  *       or 90 degrees up from where the wrist naturally hangs).
  */
@@ -48,7 +48,7 @@ public class WristMechanism {
   LoggedTunableNumber wristExpokA;
 
   LoggedTunableNumber wristTuningSetpointRotations;
-  LoggedTunableNumber wristTuningOverrideAmps;
+  LoggedTunableNumber wristTuningOverrideVolts;
 
   public WristMechanism(WristIO io) {
     wristkP =
@@ -80,7 +80,8 @@ public class WristMechanism {
 
     wristTuningSetpointRotations =
         new LoggedTunableNumber("WristTunables/wristTuningSetpointRotations", 0.0);
-    wristTuningOverrideAmps = new LoggedTunableNumber("WristTunables/wristTuningOverrideAmps", 0.0);
+    wristTuningOverrideVolts =
+        new LoggedTunableNumber("WristTunables/wristTuningOverrideVolts", 0.0);
 
     this.io = io;
   }
@@ -142,13 +143,13 @@ public class WristMechanism {
             },
             wristTuningSetpointRotations);
         break;
-      case WristCurrentTuning:
+      case WristVoltageTuning:
         LoggedTunableNumber.ifChanged(
             hashCode(),
             (setpoint) -> {
-              io.setOverrideCurrent(Amps.of(setpoint[0]));
+              io.setOverrideVoltage(Volts.of(setpoint[0]));
             },
-            wristTuningOverrideAmps);
+            wristTuningOverrideVolts);
         io.setOverrideMode(true);
         break;
       default:


### PR DESCRIPTION
Wrist was originally written for FOC but it was much more consistent in sim when using voltage output, so this PR fixes any inconsistencies left over from switching between the two.