### PR TITLE
Prevent wrist slamming down on enable

### DIFF
--- a/src/main/deploy/constants/config.json
+++ b/src/main/deploy/constants/config.json
@@ -1,5 +1,5 @@
 {
-  "environment": "comp",
+  "environment": "test_drivebase",
   "defaults": "comp",
   "environments": [
     {

--- a/src/main/java/frc/robot/subsystems/scoring/states/InitState.java
+++ b/src/main/java/frc/robot/subsystems/scoring/states/InitState.java
@@ -41,6 +41,8 @@ public class InitState implements PeriodicStateInterface {
 
   @Override
   public void periodic() {
+    scoringSubsystem.setWristGoalAngle(JsonConstants.scoringSetpoints.idle.wristAngle());
+
     if (!DriverStation.isEnabled()) {
       homingTimer.restart();
       return;


### PR DESCRIPTION
Make scoring InitState set wrist goal angle to idle, instead of going to zero like it did before. This stops the wrist from slamming down during homing.