### PR TITLE
Improve algae reliability

### DIFF
--- a/src/main/deploy/constants/ScoringSetpoints.json
+++ b/src/main/deploy/constants/ScoringSetpoints.json
@@ -120,6 +120,17 @@
       "unit": "Rotation"
     }
   },
+  "netWarmup": {
+    "name": "netWarmup",
+    "elevatorHeight": {
+      "value": 0.25,
+      "unit": "Meter"
+    },
+    "wristAngle": {
+      "value": -0.105,
+      "unit": "Rotation"
+    }
+  },
   "net": {
     "name": "net",
     "elevatorHeight": {

--- a/src/main/deploy/constants/comp/ClawConstants.json
+++ b/src/main/deploy/constants/comp/ClawConstants.json
@@ -29,8 +29,12 @@
     "unit": "Centimeter"
   },
   "algaeMinSignalStrengthForValidMeasurement": 2500.0,
-  "intakeVoltage": {
+  "coralIntakeVoltage": {
     "value": 1.5,
+    "unit": "Volt"
+  },
+  "algaeIntakeVoltage": {
+    "value": -1.5,
     "unit": "Volt"
   },
   "coralScoreVoltage": {
@@ -38,7 +42,7 @@
     "unit": "Volt"
   },
   "algaeScoreVoltage": {
-    "value": -3.0,
+    "value": -12.0,
     "unit": "Volt"
   },
   "intakeAnglePastCoralrange": {

--- a/src/main/deploy/constants/comp/ClawConstants.json
+++ b/src/main/deploy/constants/comp/ClawConstants.json
@@ -42,7 +42,7 @@
     "unit": "Volt"
   },
   "algaeScoreVoltage": {
-    "value": -12.0,
+    "value": 12.0,
     "unit": "Volt"
   },
   "intakeAnglePastCoralrange": {

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 98;
-  public static final String GIT_SHA = "7d366efad86c4e528f267f51a4d6f75e0e432770";
-  public static final String GIT_DATE = "2025-03-04 12:40:22 EST";
-  public static final String GIT_BRANCH = "lineup-tune";
-  public static final String BUILD_DATE = "2025-03-04 16:23:41 EST";
-  public static final long BUILD_UNIX_TIME = 1741123421302L;
+  public static final int GIT_REVISION = 53;
+  public static final String GIT_SHA = "d0cc9355449ee7866ea72239ecbd079f5e57482d";
+  public static final String GIT_DATE = "2025-03-04 16:32:57 EST";
+  public static final String GIT_BRANCH = "147-reliable-algae";
+  public static final String BUILD_DATE = "2025-03-04 16:37:12 EST";
+  public static final long BUILD_UNIX_TIME = 1741124232922L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/InitBindings.java
+++ b/src/main/java/frc/robot/InitBindings.java
@@ -285,7 +285,7 @@ public final class InitBindings {
                 new InstantCommand(
                     () -> {
                       ScoringSubsystem.getInstance()
-                          .setClawRollerVoltage(JsonConstants.clawConstants.intakeVoltage);
+                          .setClawRollerVoltage(JsonConstants.clawConstants.coralIntakeVoltage);
                     }))
             .onFalse(
                 new InstantCommand(
@@ -301,7 +301,7 @@ public final class InitBindings {
                     () -> {
                       ScoringSubsystem.getInstance()
                           .setClawRollerVoltage(
-                              JsonConstants.clawConstants.intakeVoltage.times(-0.5));
+                              JsonConstants.clawConstants.coralIntakeVoltage.times(-0.5));
                     }))
             .onFalse(
                 new InstantCommand(

--- a/src/main/java/frc/robot/constants/ClawConstants.java
+++ b/src/main/java/frc/robot/constants/ClawConstants.java
@@ -45,7 +45,8 @@ public class ClawConstants {
   public final Distance algaeProximityHysteresis = Centimeters.of(0.5);
   public final double algaeMinSignalStrengthForValidMeasurement = 2500.0;
 
-  public final Voltage intakeVoltage = Volts.of(3.0);
+  public final Voltage coralIntakeVoltage = Volts.of(3.0);
+  public final Voltage algaeIntakeVoltage = Volts.of(-3.0);
   public final Voltage coralScoreVoltage = Volts.of(3.0);
   public final Voltage algaeScoreVoltage = Volts.of(-3.0);
 

--- a/src/main/java/frc/robot/constants/ScoringSetpoints.java
+++ b/src/main/java/frc/robot/constants/ScoringSetpoints.java
@@ -57,6 +57,9 @@ public class ScoringSetpoints {
 
   public final ScoringSetpoint processor =
       new ScoringSetpoint("processor", Meters.of(0.1), Rotations.of(-0.75));
+
+  public final ScoringSetpoint netWarmup =
+      new ScoringSetpoint("netWarmup", Meters.of(0.25), Rotations.of(-0.105));
   public final ScoringSetpoint net =
       new ScoringSetpoint("net", Meters.of(1.25), Rotations.of(-0.75));
 
@@ -79,7 +82,7 @@ public class ScoringSetpoints {
       case L4:
         return JsonConstants.scoringSetpoints.L4;
       case Net:
-        return JsonConstants.scoringSetpoints.net;
+        return JsonConstants.scoringSetpoints.netWarmup;
       case Processor:
         return JsonConstants.scoringSetpoints.processor;
       case Ground:

--- a/src/main/java/frc/robot/subsystems/scoring/states/IntakeState.java
+++ b/src/main/java/frc/robot/subsystems/scoring/states/IntakeState.java
@@ -47,9 +47,9 @@ public class IntakeState implements PeriodicStateInterface {
   // @Override
   public void periodic() {
     if (scoringSubsystem.getGamePiece() == GamePiece.Algae) {
-      scoringSubsystem.setClawRollerVoltage(JsonConstants.clawConstants.intakeVoltage.times(-1));
+      scoringSubsystem.setClawRollerVoltage(JsonConstants.clawConstants.algaeIntakeVoltage);
     } else {
-      scoringSubsystem.setClawRollerVoltage(JsonConstants.clawConstants.intakeVoltage);
+      scoringSubsystem.setClawRollerVoltage(JsonConstants.clawConstants.coralIntakeVoltage);
     }
 
     ScoringSetpoint setpoint;


### PR DESCRIPTION
- Separate algae and coral intake voltages
- Increase algae score voltage to 12
- When scoring in the net:
  - Warmup takes elevator to a height around L2 height and waits
  - Score commands elevator all the way up, as soon as elevator is near the top applies 12V to kick the algae out of the claw using vertical momentum from elevator

This PR should also be used to fix any algae reliability issues (state machine was getting stuck but I think that's fixed) so will remain as a bit of an integration branch (should be pretty quick to verify).