### PR TITLE
Add far warmup to scoring

### DIFF
--- a/src/main/deploy/constants/ScoringSetpoints.json
+++ b/src/main/deploy/constants/ScoringSetpoints.json
@@ -65,6 +65,17 @@
       "unit": "Rotation"
     }
   },
+  "farWarmup": {
+    "name": "farWarmup",
+    "elevatorHeight": {
+      "value": 0.65,
+      "unit": "Meter"
+    },
+    "wristAngle": {
+      "value": 0.3,
+      "unit": "Rotation"
+    }
+  },
   "L2algae": {
     "name": "L2algae",
     "elevatorHeight": {

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 59;
-  public static final String GIT_SHA = "18a2ac2728ca7a3f28524591d3f575a2f39abeb5";
-  public static final String GIT_DATE = "2025-03-03 09:01:01 EST";
-  public static final String GIT_BRANCH = "dynamic-obstacles";
-  public static final String BUILD_DATE = "2025-03-03 10:37:11 EST";
-  public static final long BUILD_UNIX_TIME = 1741016231954L;
+  public static final int GIT_REVISION = 49;
+  public static final String GIT_SHA = "e505f3283ec28160a74adb50a3bad0ffd599a588";
+  public static final String GIT_DATE = "2025-03-04 08:20:43 EST";
+  public static final String GIT_BRANCH = "90-warmup-before-lineup";
+  public static final String BUILD_DATE = "2025-03-04 13:22:35 EST";
+  public static final long BUILD_UNIX_TIME = 1741112555527L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/commands/strategies/AutoScore.java
+++ b/src/main/java/frc/robot/commands/strategies/AutoScore.java
@@ -40,7 +40,6 @@ public class AutoScore extends Command {
     if (scoringSubsystem != null) {
       scoringSubsystem.setGamePiece(GamePiece.Coral);
       scoringSubsystem.setTarget(currentFieldTarget);
-      scoringSubsystem.setAutoTransition(true);
     }
   }
 

--- a/src/main/java/frc/robot/constants/ScoringSetpoints.java
+++ b/src/main/java/frc/robot/constants/ScoringSetpoints.java
@@ -43,6 +43,9 @@ public class ScoringSetpoints {
   public final ScoringSetpoint L3 = new ScoringSetpoint("L3", Meters.of(2.0), Rotations.of(0.3214));
   public final ScoringSetpoint L4 = new ScoringSetpoint("L4", Meters.of(2.5), Rotations.of(0.3214));
 
+  public final ScoringSetpoint farWarmup =
+      new ScoringSetpoint("farWarmup", Meters.of(0.6), Rotations.of(0.3214));
+
   // TODO: Algae setpoints
   public final ScoringSetpoint L2algae =
       new ScoringSetpoint("L2algae", Meters.of(1.8), Rotations.of(-0.75));

--- a/src/main/java/frc/robot/constants/subsystems/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/constants/subsystems/DrivetrainConstants.java
@@ -90,6 +90,8 @@ public class DrivetrainConstants {
   public final Double otfPoseDistanceLimit = 0.1;
   public final Double otfPoseEndingVelocity = 0.5;
 
+  public final Double otfFarWarmupDistance = 1.0;
+
   // The closed-loop output type to use for the steer motors;
   // This affects the PID/FF gains for the steer motors
   public final ClosedLoopOutputType kSteerClosedLoopOutput = ClosedLoopOutputType.Voltage;

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -561,6 +561,14 @@ public class Drive implements DriveTemplate {
         < JsonConstants.drivetrainConstants.otfPoseDistanceLimit;
   }
 
+  @AutoLogOutput(key = "Drive/OTF/isDriveCloseForFarWarmup")
+  public boolean isDriveCloseForFarWarmup() {
+    return this.getPose()
+            .getTranslation()
+            .getDistance(OTFState.findOTFPoseFromDesiredLocation(this).getTranslation())
+        < JsonConstants.drivetrainConstants.otfFarWarmupDistance;
+  }
+
   /**
    * checks if drive is currently lining up to a reef
    *

--- a/src/main/java/frc/robot/subsystems/drive/states/OTFState.java
+++ b/src/main/java/frc/robot/subsystems/drive/states/OTFState.java
@@ -10,6 +10,8 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.constants.JsonConstants;
 import frc.robot.subsystems.drive.Drive;
 import frc.robot.subsystems.drive.Drive.DriveTrigger;
+import frc.robot.subsystems.scoring.ScoringSubsystem;
+import frc.robot.subsystems.scoring.ScoringSubsystem.ScoringTrigger;
 import org.littletonrobotics.junction.Logger;
 
 public class OTFState implements PeriodicStateInterface {
@@ -159,6 +161,10 @@ public class OTFState implements PeriodicStateInterface {
     // finishes otf when we are 0.1 meters away
     if (drive.isDriveCloseToFinalLineupPose()) {
       drive.fireTrigger(DriveTrigger.FinishOTF);
+    }
+
+    if (drive.isDriveCloseForFarWarmup() && ScoringSubsystem.getInstance() != null) {
+      ScoringSubsystem.getInstance().fireTrigger(ScoringTrigger.StartFarWarmup);
     }
 
     if (driveToPose != null) {

--- a/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
@@ -27,6 +27,7 @@ import frc.robot.TestModeManager.TestMode;
 import frc.robot.constants.JsonConstants;
 import frc.robot.constants.ScoringSetpoints.ScoringSetpoint;
 import frc.robot.subsystems.scoring.ElevatorIO.ElevatorOutputMode;
+import frc.robot.subsystems.scoring.states.FarWarmupState;
 import frc.robot.subsystems.scoring.states.IdleState;
 import frc.robot.subsystems.scoring.states.InitState;
 import frc.robot.subsystems.scoring.states.IntakeState;
@@ -108,12 +109,19 @@ public class ScoringSubsystem extends MonitoredSubsystem {
   private static ScoringSubsystem instance;
 
   /**
-   * Whether or not we should automatically transition through the workflow Idle -> Intake -> Warmup
-   * -> Score
+   * Keep track of what state to go into after init
+   *
+   * <p>If a trigger is fired to enter warmup while in init, it will go into warmup. If a trigger
+   * for far warmup is fired, it will go into far warmup. Multiple triggers are fired, the most
+   * recent trigger will apply.
    */
-  private boolean autoTransition = true;
+  private enum StateAfterInit {
+    Idle,
+    Warmup,
+    FarWarmup
+  }
 
-  private boolean shouldWarmupAfterInit = false;
+  private StateAfterInit warmupStateAfterInit = StateAfterInit.Idle;
 
   private BooleanSupplier isDriveLinedUpSupplier;
 
@@ -146,6 +154,7 @@ public class ScoringSubsystem extends MonitoredSubsystem {
     Init(new InitState(instance)),
     Idle(new IdleState(instance)),
     Intake(new IntakeState(instance)),
+    FarWarmup(new FarWarmupState(instance)),
     Warmup(new WarmupState(instance)),
     Score(new ScoreState(instance)),
     Tuning(new TuningState());
@@ -167,8 +176,8 @@ public class ScoringSubsystem extends MonitoredSubsystem {
     BeginIntake,
     CancelIntake,
     DoneIntaking,
-    ToggleWarmup, // warmup button toggles warmup <-> idle
     StartWarmup, // drive automatically enters warmup when lineup begins
+    StartFarWarmup, // Start a "far warmup" when drive is a certain distance from it's OTF target
     WarmupReady,
     CancelWarmup, // Warmup button was released, go back to idle
     ScoredPiece,
@@ -214,11 +223,22 @@ public class ScoringSubsystem extends MonitoredSubsystem {
         .permitIf(
             ScoringTrigger.Seeded,
             ScoringState.Warmup,
-            () -> !isScoringTuningSupplier.getAsBoolean() && shouldWarmupAfterInit)
+            () ->
+                !isScoringTuningSupplier.getAsBoolean()
+                    && warmupStateAfterInit == StateAfterInit.Warmup)
+        .permitIf(
+            ScoringTrigger.Seeded,
+            ScoringState.FarWarmup,
+            () ->
+                !isScoringTuningSupplier.getAsBoolean()
+                    && warmupStateAfterInit == StateAfterInit.FarWarmup
+                    && canFarWarmup())
         .permitIf(
             ScoringTrigger.Seeded,
             ScoringState.Idle,
-            () -> !isScoringTuningSupplier.getAsBoolean() && !shouldWarmupAfterInit);
+            () ->
+                !isScoringTuningSupplier.getAsBoolean()
+                    && warmupStateAfterInit == StateAfterInit.Idle);
 
     stateMachineConfiguration
         .configure(ScoringState.Idle)
@@ -226,7 +246,7 @@ public class ScoringSubsystem extends MonitoredSubsystem {
             ScoringTrigger.BeginIntake,
             ScoringState.Intake,
             () -> !(isCoralDetected() || isAlgaeDetected()))
-        .permit(ScoringTrigger.ToggleWarmup, ScoringState.Warmup)
+        .permitIf(ScoringTrigger.StartFarWarmup, ScoringState.FarWarmup, () -> canFarWarmup())
         .permit(ScoringTrigger.StartWarmup, ScoringState.Warmup)
         .permitIf(ScoringTrigger.EnterTestMode, ScoringState.Tuning, isScoringTuningSupplier);
 
@@ -236,20 +256,22 @@ public class ScoringSubsystem extends MonitoredSubsystem {
 
     stateMachineConfiguration
         .configure(ScoringState.Intake)
-        // If autoTransition, go straight to warmup from intake once we're done
-        // Otherwise, return to idle
         .permit(ScoringTrigger.DoneIntaking, ScoringState.Idle)
         .permit(ScoringTrigger.CancelIntake, ScoringState.Idle);
 
     stateMachineConfiguration
         .configure(ScoringState.Warmup)
-        .permit(ScoringTrigger.ToggleWarmup, ScoringState.Idle)
         // Allow warmup to transition to scoring if autoTransition is enabled and we are lined up
         .permitIf(
             ScoringTrigger.WarmupReady,
             ScoringState.Score,
-            () -> autoTransition && isDriveLinedUpSupplier.getAsBoolean())
+            () -> isDriveLinedUpSupplier.getAsBoolean())
         .permit(ScoringTrigger.ReturnToIdle, ScoringState.Idle)
+        .permit(ScoringTrigger.CancelWarmup, ScoringState.Idle);
+
+    stateMachineConfiguration
+        .configure(ScoringState.FarWarmup)
+        .permit(ScoringTrigger.StartWarmup, ScoringState.Warmup)
         .permit(ScoringTrigger.CancelWarmup, ScoringState.Idle);
 
     stateMachineConfiguration
@@ -302,14 +324,15 @@ public class ScoringSubsystem extends MonitoredSubsystem {
   }
 
   /**
-   * Set whether or not the scoring subsystem should automatically transition through its states
-   * (e.g. automatically enter warmup when drive starts lining up, automatically go to score when
-   * warmup is ready, etc.)
+   * Can the scoring subsystem warmup for far warmup at the moment?
    *
-   * @param shouldAutoTransition True if auto transition is enabled, false if not
+   * <p>This is true if the gamepiece is coral and the field target is L3 or L4
+   *
+   * @return
    */
-  public void setAutoTransition(boolean shouldAutoTransition) {
-    this.autoTransition = shouldAutoTransition;
+  public boolean canFarWarmup() {
+    return currentPiece == GamePiece.Coral
+        && (currentTarget == FieldTarget.L3 || currentTarget == FieldTarget.L4);
   }
 
   public void setIsDriveLinedUpSupplier(BooleanSupplier newSupplier) {
@@ -324,9 +347,17 @@ public class ScoringSubsystem extends MonitoredSubsystem {
   public void fireTrigger(ScoringTrigger trigger) {
     stateMachine.fire(trigger);
 
-    if (trigger == ScoringTrigger.StartWarmup
-        && stateMachine.getCurrentState() == ScoringState.Init) {
-      shouldWarmupAfterInit = true;
+    if (stateMachine.getCurrentState() == ScoringState.Init) {
+      switch (trigger) {
+        case StartWarmup:
+          warmupStateAfterInit = StateAfterInit.Warmup;
+          break;
+        case StartFarWarmup:
+          warmupStateAfterInit = StateAfterInit.FarWarmup;
+          break;
+        default:
+          break;
+      }
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/scoring/states/FarWarmupState.java
+++ b/src/main/java/frc/robot/subsystems/scoring/states/FarWarmupState.java
@@ -1,0 +1,33 @@
+package frc.robot.subsystems.scoring.states;
+
+import static edu.wpi.first.units.Units.Volts;
+
+import coppercore.controls.state_machine.state.PeriodicStateInterface;
+import coppercore.controls.state_machine.transition.Transition;
+import frc.robot.constants.JsonConstants;
+import frc.robot.constants.ScoringSetpoints.ScoringSetpoint;
+import frc.robot.subsystems.scoring.ScoringSubsystem;
+import frc.robot.subsystems.scoring.ScoringSubsystem.ScoringTrigger;
+
+public class FarWarmupState implements PeriodicStateInterface {
+  private ScoringSubsystem scoringSubsystem;
+
+  public FarWarmupState(ScoringSubsystem scoringSubsystem) {
+    this.scoringSubsystem = scoringSubsystem;
+  }
+
+  @Override
+  public void onEntry(Transition transition) {}
+
+  @Override
+  public void periodic() {
+    ScoringSetpoint setpoint = JsonConstants.scoringSetpoints.farWarmup;
+
+    scoringSubsystem.setGoalSetpoint(setpoint);
+    scoringSubsystem.setClawRollerVoltage(Volts.zero());
+
+    if (!(scoringSubsystem.isAlgaeDetected() || scoringSubsystem.isCoralDetected())) {
+      scoringSubsystem.fireTrigger(ScoringTrigger.ReturnToIdle);
+    }
+  }
+}


### PR DESCRIPTION
Adds a new state to scoring in between idle and warmup that can be used to raise the elevator a little to shorten warmup times for L3 and L4 scoring.