### PR TITLE
Intentionally throw algae into the net

### DIFF
--- a/src/main/deploy/constants/ScoringSetpoints.json
+++ b/src/main/deploy/constants/ScoringSetpoints.json
@@ -83,7 +83,7 @@
       "unit": "Meter"
     },
     "wristAngle": {
-      "value": -0.105,
+      "value": -0.095,
       "unit": "Rotation"
     }
   },
@@ -94,7 +94,7 @@
       "unit": "Meter"
     },
     "wristAngle": {
-      "value": -0.105,
+      "value": -0.095,
       "unit": "Rotation"
     }
   },

--- a/src/main/deploy/constants/ScoringSetpoints.json
+++ b/src/main/deploy/constants/ScoringSetpoints.json
@@ -123,12 +123,12 @@
   "netWarmup": {
     "name": "netWarmup",
     "elevatorHeight": {
-      "value": 0.25,
+      "value": 1.55,
       "unit": "Meter"
     },
     "wristAngle": {
-      "value": -0.105,
-      "unit": "Rotation"
+      "value": 1.3,
+      "unit": "Radian"
     }
   },
   "net": {

--- a/src/main/deploy/constants/ScoringSetpoints.json
+++ b/src/main/deploy/constants/ScoringSetpoints.json
@@ -123,7 +123,7 @@
   "netWarmup": {
     "name": "netWarmup",
     "elevatorHeight": {
-      "value": 1.55,
+      "value": 1.8,
       "unit": "Meter"
     },
     "wristAngle": {

--- a/src/main/deploy/constants/comp/ElevatorConstants.json
+++ b/src/main/deploy/constants/comp/ElevatorConstants.json
@@ -86,5 +86,9 @@
     "value": 0.05,
     "unit": "Meter"
   },
-  "maxElevatorSetpointVelocityMetersPerSecond": 0.01
+  "maxElevatorSetpointVelocityMetersPerSecond": 0.01,
+  "minAlgaeInHeight": {
+    "value": 1.7,
+    "unit": "Meter"
+  }
 }

--- a/src/main/deploy/constants/comp/WristConstants.json
+++ b/src/main/deploy/constants/comp/WristConstants.json
@@ -61,5 +61,9 @@
     "unit": "Degree"
   },
   "maxWristSetpointVelocityRotationsPerSecond": 0.008333,
-  "wristStableDebounceTimeSeconds": 0.1
+  "wristStableDebounceTimeSeconds": 0.1,
+  "algaeUnderCrossbarAngle": {
+    "value": -0.105,
+    "unit": "Radian"
+  }
 }

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 53;
-  public static final String GIT_SHA = "4d5729e7227e5cfd5892a2a96a3d55fa73420bf0";
-  public static final String GIT_DATE = "2025-03-05 20:12:33 EST";
+  public static final int GIT_REVISION = 55;
+  public static final String GIT_SHA = "5b353730fc70580d24fe1964849632f392fe4b9b";
+  public static final String GIT_DATE = "2025-03-06 09:22:55 EST";
   public static final String GIT_BRANCH = "154-mlg-algae";
-  public static final String BUILD_DATE = "2025-03-05 20:32:09 EST";
-  public static final long BUILD_UNIX_TIME = 1741224729814L;
+  public static final String BUILD_DATE = "2025-03-06 12:31:53 EST";
+  public static final long BUILD_UNIX_TIME = 1741282313205L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -3,14 +3,14 @@ package frc.robot;
 /** Automatically generated file containing build version information. */
 public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
-  public static final String MAVEN_NAME = "2025-Robot-Code-3";
+  public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 69;
-  public static final String GIT_SHA = "a34d781bf379048741fb32b64347dfd553c3d696";
-  public static final String GIT_DATE = "2025-03-05 17:12:37 EST";
-  public static final String GIT_BRANCH = "comp-auto-integration";
-  public static final String BUILD_DATE = "2025-03-05 19:46:43 EST";
-  public static final long BUILD_UNIX_TIME = 1741222003541L;
+  public static final int GIT_REVISION = 53;
+  public static final String GIT_SHA = "4d5729e7227e5cfd5892a2a96a3d55fa73420bf0";
+  public static final String GIT_DATE = "2025-03-05 20:12:33 EST";
+  public static final String GIT_BRANCH = "154-mlg-algae";
+  public static final String BUILD_DATE = "2025-03-05 20:32:09 EST";
+  public static final long BUILD_UNIX_TIME = 1741224729814L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -3,14 +3,14 @@ package frc.robot;
 /** Automatically generated file containing build version information. */
 public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
-  public static final String MAVEN_NAME = "2025-Robot-Code";
+  public static final String MAVEN_NAME = "2025-Robot-Code-3";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 56;
-  public static final String GIT_SHA = "eab20311f1e2f33b2a6d9b08969783a39d671bef";
-  public static final String GIT_DATE = "2025-03-06 12:32:28 EST";
+  public static final int GIT_REVISION = 57;
+  public static final String GIT_SHA = "248a59d89e4a335b9c5099c4bd1514b1682296b0";
+  public static final String GIT_DATE = "2025-03-06 16:28:30 EST";
   public static final String GIT_BRANCH = "154-mlg-algae";
-  public static final String BUILD_DATE = "2025-03-06 16:28:05 EST";
-  public static final long BUILD_UNIX_TIME = 1741296485224L;
+  public static final String BUILD_DATE = "2025-03-06 20:07:07 EST";
+  public static final long BUILD_UNIX_TIME = 1741309627371L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 55;
-  public static final String GIT_SHA = "5b353730fc70580d24fe1964849632f392fe4b9b";
-  public static final String GIT_DATE = "2025-03-06 09:22:55 EST";
+  public static final int GIT_REVISION = 56;
+  public static final String GIT_SHA = "eab20311f1e2f33b2a6d9b08969783a39d671bef";
+  public static final String GIT_DATE = "2025-03-06 12:32:28 EST";
   public static final String GIT_BRANCH = "154-mlg-algae";
-  public static final String BUILD_DATE = "2025-03-06 12:31:53 EST";
-  public static final long BUILD_UNIX_TIME = 1741282313205L;
+  public static final String BUILD_DATE = "2025-03-06 16:28:05 EST";
+  public static final long BUILD_UNIX_TIME = 1741296485224L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/constants/WristConstants.java
+++ b/src/main/java/frc/robot/constants/WristConstants.java
@@ -106,6 +106,8 @@ public class WristConstants {
 
   public final Double wristStableDebounceTimeSeconds = 0.5;
 
+  public final Angle algaeUnderCrossbarAngle = Radians.of(-0.105);
+
   public static final class Sim {
     @JSONExclude
     public static final JSONSync<WristConstants.Sim> synced =

--- a/src/main/java/frc/robot/constants/subsystems/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/subsystems/ElevatorConstants.java
@@ -193,7 +193,10 @@ public final class ElevatorConstants {
   /** When within this distance, the elevator is considered "at its setpoint" */
   public final Distance elevatorSetpointEpsilon = Meters.of(0.05);
 
-  /** How high elevator must go before we can swing the algae up into the robot without getting stuck on crossbar or elevator */
+  /**
+   * How high elevator must go before we can swing the algae up into the robot without getting stuck
+   * on crossbar or elevator
+   */
   public final Distance minAlgaeInHeight = Meters.of(1.5);
 
   /**

--- a/src/main/java/frc/robot/constants/subsystems/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/subsystems/ElevatorConstants.java
@@ -193,6 +193,9 @@ public final class ElevatorConstants {
   /** When within this distance, the elevator is considered "at its setpoint" */
   public final Distance elevatorSetpointEpsilon = Meters.of(0.05);
 
+  /** How high elevator must go before we can swing the algae up into the robot without getting stuck on crossbar or elevator */
+  public final Distance minAlgaeInHeight = Meters.of(1.5);
+
   /**
    * How slow must the elevator move before it is considered to be stable at its goal position
    *

--- a/src/main/java/frc/robot/constants/subsystems/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/subsystems/ElevatorConstants.java
@@ -197,7 +197,7 @@ public final class ElevatorConstants {
    * How high elevator must go before we can swing the algae up into the robot without getting stuck
    * on crossbar or elevator
    */
-  public final Distance minAlgaeInHeight = Meters.of(1.5);
+  public final Distance minAlgaeInHeight = Meters.of(1.7);
 
   /**
    * How slow must the elevator move before it is considered to be stable at its goal position

--- a/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
@@ -820,12 +820,23 @@ public class ScoringSubsystem extends MonitoredSubsystem {
       }
     }
 
+    boolean wristDownForAlgae = false;
+    if (isAlgaeDetected()
+        && elevatorMechanism
+            .getElevatorHeight()
+            .lt(JsonConstants.elevatorConstants.minAlgaeInHeight)) {
+      wristDownForAlgae = true;
+      wristMaxAngle.mut_replace(
+          (Angle) Measure.min(wristMaxAngle, JsonConstants.wristConstants.algaeUnderCrossbarAngle));
+    }
+
     Logger.recordOutput("scoring/clamps/closeToReef", closeToReef);
     Logger.recordOutput("scoring/clamps/wristInToAvoidReefBase", wristInToAvoidReefBase);
     Logger.recordOutput("scoring/clamps/elevatorUpToAvoidReefBase", elevatorUpToAvoidReefBase);
     Logger.recordOutput("scoring/clamps/wristInToPassReef", wristInToPassReef);
     Logger.recordOutput("scoring/clamps/elevatorBelowReefLevel", elevatorBelowReefLevel);
     Logger.recordOutput("scoring/clamps/elevatorAboveReefLevel", elevatorAboveReefLevel);
+    Logger.recordOutput("scoring/clamps/wristDownForAlgae", wristDownForAlgae);
 
     elevatorMechanism.setAllowedRangeOfMotion(elevatorMinHeight, elevatorMaxHeight);
     wristMechanism.setAllowedRangeOfMotion(wristMinAngle, wristMaxAngle);

--- a/src/main/java/frc/robot/subsystems/scoring/states/ScoreState.java
+++ b/src/main/java/frc/robot/subsystems/scoring/states/ScoreState.java
@@ -8,7 +8,6 @@ import frc.robot.constants.ScoringSetpoints;
 import frc.robot.constants.ScoringSetpoints.ScoringSetpoint;
 import frc.robot.subsystems.scoring.ScoringSubsystem;
 import frc.robot.subsystems.scoring.ScoringSubsystem.FieldTarget;
-import frc.robot.subsystems.scoring.ScoringSubsystem.GamePiece;
 import frc.robot.subsystems.scoring.ScoringSubsystem.ScoringTrigger;
 
 public class ScoreState implements PeriodicStateInterface {
@@ -21,14 +20,8 @@ public class ScoreState implements PeriodicStateInterface {
   @Override
   public void periodic() {
     ScoringSetpoint setpoint;
-    if (scoringSubsystem.getGamePiece() == GamePiece.Algae
-        && scoringSubsystem.getTarget() == FieldTarget.Net) {
-      // Force the net setpoint only in score since the "warmup" for the net stays low to use
-      // elevator to shoot algae upward
-      setpoint = JsonConstants.scoringSetpoints.net;
-    } else {
-      setpoint = ScoringSetpoints.getWarmupSetpoint(scoringSubsystem.getTarget());
-    }
+    // Only warmup like normal when we aren't doing algae in the net
+    setpoint = ScoringSetpoints.getWarmupSetpoint(scoringSubsystem.getTarget());
 
     scoringSubsystem.setGoalSetpoint(setpoint);
 
@@ -45,7 +38,7 @@ public class ScoreState implements PeriodicStateInterface {
           if (scoringSubsystem
               .getElevatorHeight()
               .isNear(
-                  setpoint.elevatorHeight(),
+                  JsonConstants.scoringSetpoints.net.elevatorHeight(),
                   JsonConstants.elevatorConstants.elevatorSetpointEpsilon)) {
             scoringSubsystem.setClawRollerVoltage(JsonConstants.clawConstants.algaeScoreVoltage);
           } else {

--- a/src/main/java/frc/robot/subsystems/scoring/states/ScoreState.java
+++ b/src/main/java/frc/robot/subsystems/scoring/states/ScoreState.java
@@ -8,6 +8,7 @@ import frc.robot.constants.ScoringSetpoints;
 import frc.robot.constants.ScoringSetpoints.ScoringSetpoint;
 import frc.robot.subsystems.scoring.ScoringSubsystem;
 import frc.robot.subsystems.scoring.ScoringSubsystem.FieldTarget;
+import frc.robot.subsystems.scoring.ScoringSubsystem.GamePiece;
 import frc.robot.subsystems.scoring.ScoringSubsystem.ScoringTrigger;
 
 public class ScoreState implements PeriodicStateInterface {
@@ -20,8 +21,16 @@ public class ScoreState implements PeriodicStateInterface {
   @Override
   public void periodic() {
     ScoringSetpoint setpoint;
+
     // Only warmup like normal when we aren't doing algae in the net
-    setpoint = ScoringSetpoints.getWarmupSetpoint(scoringSubsystem.getTarget());
+    if (scoringSubsystem.getGamePiece() == GamePiece.Algae
+        && scoringSubsystem.getTarget() == FieldTarget.Net) {
+      // Force the net setpoint only in score since the "warmup" for the net stays low to use
+      // elevator to shoot algae upward
+      setpoint = JsonConstants.scoringSetpoints.net;
+    } else {
+      setpoint = ScoringSetpoints.getWarmupSetpoint(scoringSubsystem.getTarget());
+    }
 
     scoringSubsystem.setGoalSetpoint(setpoint);
 


### PR DESCRIPTION
Hold the wrist pointed upward and the elevator below max height in warmup for net, then snap wrist out to score positions while running rollers in score to throw the algae into the net.

This also adds a protection clamp to scoring to keep the wrist under a certain angle when there's an algae in the robot and the elevator is below a certain height to avoid slapping the algae into the crossbar or a stage of the elevator.