### PR TITLE
Actually run rollers when scoring algae into processor in ScoreState

### DIFF
--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,13 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 61;
-  public static final String GIT_SHA = "6ba3f48638f63674e547d62838f8603e05f036a3";
-  public static final String GIT_DATE = "2025-03-06 19:42:49 EST";
-  public static final String GIT_BRANCH = "elevator-setpoint-fix";
-  public static final String BUILD_DATE = "2025-03-07 08:29:10 EST";
-  public static final long BUILD_UNIX_TIME = 1741354150102L;
-
+  public static final int GIT_REVISION = 55;
+  public static final String GIT_SHA = "4730de9777efaed4bc8189514e5921f1de65ae25";
+  public static final String GIT_DATE = "2025-03-07 11:51:01 EST";
+  public static final String GIT_BRANCH = "162-processor-score-fix";
+  public static final String BUILD_DATE = "2025-03-07 12:05:51 EST";
+  public static final long BUILD_UNIX_TIME = 1741367151777L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/subsystems/scoring/states/ScoreState.java
+++ b/src/main/java/frc/robot/subsystems/scoring/states/ScoreState.java
@@ -51,6 +51,9 @@ public class ScoreState implements PeriodicStateInterface {
           } else {
             scoringSubsystem.setClawRollerVoltage(Volts.zero());
           }
+        } else {
+          // If scoring algae but not in the net, run the rollers (score processor as normal)
+          scoringSubsystem.setClawRollerVoltage(JsonConstants.clawConstants.algaeScoreVoltage);
         }
 
         if (JsonConstants.scoringFeatureFlags.runClaw) {


### PR DESCRIPTION
Previously, the net score logic was incomplete and resulted in not running the rollers when trying to score in processor

- Add an else statement to ScoreState so that the rollers run when trying to score an algae *not* into the net.