### PR TITLE
add ability to stop lineup by moving joysticks

### DIFF
--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -3,14 +3,14 @@ package frc.robot;
 /** Automatically generated file containing build version information. */
 public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
-  public static final String MAVEN_NAME = "2025-Robot-Code-3";
+  public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 68;
-  public static final String GIT_SHA = "9899bcb2854cc592c52ca78edd1259dc08feb736";
-  public static final String GIT_DATE = "2025-03-08 09:57:29 EST";
-  public static final String GIT_BRANCH = "156-ramp-work";
-  public static final String BUILD_DATE = "2025-03-08 10:03:36 EST";
-  public static final long BUILD_UNIX_TIME = 1741446216963L;
+  public static final int GIT_REVISION = 60;
+  public static final String GIT_SHA = "6b0fcdda74954c9bb64000a95907f2f5c7fe697d";
+  public static final String GIT_DATE = "2025-03-08 10:09:06 EST";
+  public static final String GIT_BRANCH = "joystick-override-lineup";
+  public static final String BUILD_DATE = "2025-03-12 11:27:53 EDT";
+  public static final long BUILD_UNIX_TIME = 1741793273583L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -456,7 +456,16 @@ public class Drive implements DriveTemplate {
    *     control), false for auto (robot centric)
    */
   public void setGoalSpeeds(ChassisSpeeds speeds, boolean fieldCentric) {
-    if (fieldCentric && stateMachine.inState(DriveState.Joystick)) {
+    // if we are in lineup, but field centric speeds are passed in that means joysticks are moving
+    // and we should cancel lineup
+    if (fieldCentric
+        && (stateMachine.inState(DriveState.Joystick) || stateMachine.inState(DriveState.Lineup))) {
+      if (stateMachine.inState(DriveState.Lineup)
+          && (speeds.vxMetersPerSecond > 0
+              || speeds.vyMetersPerSecond > 0
+              || speeds.omegaRadiansPerSecond > 0)) {
+        this.fireTrigger(DriveTrigger.CancelLineup);
+      }
       // Adjust for field-centric control
       boolean isFlipped =
           DriverStation.getAlliance().isPresent()


### PR DESCRIPTION
- lineup will stop running if any field centric speeds are passed to the robot with greater than 0 velocity (angular, vx, or vy)