### PR TITLE
Actually use snakescreen scoring level and Smart mode intake location in Smart autonomy

### DIFF
--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 66;
-  public static final String GIT_SHA = "261f22df0813eae7f25e98b33efe4213bf5460ab";
-  public static final String GIT_DATE = "2025-03-15 19:08:18 EDT";
+  public static final int GIT_REVISION = 67;
+  public static final String GIT_SHA = "b8d6ff3fbe7624ec89c37a87a511397774876cd2";
+  public static final String GIT_DATE = "2025-03-16 14:43:07 EDT";
   public static final String GIT_BRANCH = "187-189-smart-snakescreen-fixes";
-  public static final String BUILD_DATE = "2025-03-16 14:42:23 EDT";
-  public static final long BUILD_UNIX_TIME = 1742150543395L;
+  public static final String BUILD_DATE = "2025-03-16 14:45:15 EDT";
+  public static final long BUILD_UNIX_TIME = 1742150715526L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 65;
-  public static final String GIT_SHA = "ea2a1e73b3ff08497493d4ab43e657f2294c19a4";
-  public static final String GIT_DATE = "2025-03-15 17:48:52 EDT";
-  public static final String GIT_BRANCH = "main";
-  public static final String BUILD_DATE = "2025-03-15 18:26:38 EDT";
-  public static final long BUILD_UNIX_TIME = 1742077598364L;
+  public static final int GIT_REVISION = 66;
+  public static final String GIT_SHA = "261f22df0813eae7f25e98b33efe4213bf5460ab";
+  public static final String GIT_DATE = "2025-03-15 19:08:18 EDT";
+  public static final String GIT_BRANCH = "187-189-smart-snakescreen-fixes";
+  public static final String BUILD_DATE = "2025-03-16 14:42:23 EDT";
+  public static final long BUILD_UNIX_TIME = 1742150543395L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 67;
-  public static final String GIT_SHA = "b8d6ff3fbe7624ec89c37a87a511397774876cd2";
-  public static final String GIT_DATE = "2025-03-16 14:43:07 EDT";
+  public static final int GIT_REVISION = 68;
+  public static final String GIT_SHA = "54c1879a747f3ab9f46cf932a71cc1a93f15a149";
+  public static final String GIT_DATE = "2025-03-16 14:46:32 EDT";
   public static final String GIT_BRANCH = "187-189-smart-snakescreen-fixes";
-  public static final String BUILD_DATE = "2025-03-16 14:45:15 EDT";
-  public static final long BUILD_UNIX_TIME = 1742150715526L;
+  public static final String BUILD_DATE = "2025-03-16 16:30:47 EDT";
+  public static final long BUILD_UNIX_TIME = 1742157047101L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 68;
-  public static final String GIT_SHA = "54c1879a747f3ab9f46cf932a71cc1a93f15a149";
-  public static final String GIT_DATE = "2025-03-16 14:46:32 EDT";
+  public static final int GIT_REVISION = 69;
+  public static final String GIT_SHA = "f5d7cb2ff06c407d980d207a73d7f69c2872df04";
+  public static final String GIT_DATE = "2025-03-16 16:36:57 EDT";
   public static final String GIT_BRANCH = "187-189-smart-snakescreen-fixes";
-  public static final String BUILD_DATE = "2025-03-16 16:30:47 EDT";
-  public static final long BUILD_UNIX_TIME = 1742157047101L;
+  public static final String BUILD_DATE = "2025-03-16 16:42:13 EDT";
+  public static final long BUILD_UNIX_TIME = 1742157733205L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/frc/robot/InitBindings.java
+++ b/src/main/java/frc/robot/InitBindings.java
@@ -67,6 +67,7 @@ public final class InitBindings {
                         // to avoid undoing the auto algae height selector
                         // The drive location is immediately overwritten below
                         strategyManager.updateScoringLocationsFromSnakeScreen();
+                        strategyManager.updateScoringLevelFromNetworkTables();
                       }
 
                       // When the scoring trigger is pulled in smart autonomy, select the closest

--- a/src/main/java/frc/robot/InitBindings.java
+++ b/src/main/java/frc/robot/InitBindings.java
@@ -203,11 +203,11 @@ public final class InitBindings {
                       } else {
                         if (DriverStation.getAlliance().isPresent()
                             && DriverStation.getAlliance().get() == Alliance.Red) {
-                          drive.setDesiredLocation(
+                          drive.setDesiredIntakeLocation(
                               JsonConstants.redFieldLocations.getClosestCoralStation(
                                   drive.getPose()));
                         } else {
-                          drive.setDesiredLocation(
+                          drive.setDesiredIntakeLocation(
                               JsonConstants.blueFieldLocations.getClosestCoralStation(
                                   drive.getPose()));
                         }

--- a/src/main/java/frc/robot/InitBindings.java
+++ b/src/main/java/frc/robot/InitBindings.java
@@ -192,7 +192,7 @@ public final class InitBindings {
                           || ScoringSubsystem.getInstance().getGamePiece() == GamePiece.Algae) {
                         DesiredLocation desiredLocation =
                             ReefLineupUtil.getClosestAlgaeLocation(drive.getPose());
-                        drive.setDesiredLocation(desiredLocation);
+                        drive.setDesiredIntakeLocation(desiredLocation);
 
                         // Set algae level automatically
                         if (ScoringSubsystem.getInstance() != null) {

--- a/src/main/java/frc/robot/StrategyManager.java
+++ b/src/main/java/frc/robot/StrategyManager.java
@@ -228,19 +228,20 @@ public class StrategyManager {
   public void updateScoringLocationsFromSnakeScreen() {
     // drive reef location
     if (drive != null) {
-      // Don't set reef target from SnakeScreen in 'smart' mode, this will be picked automatically
+      // Don't set reef target or intake location from SnakeScreen in 'smart' mode, this will be
+      // picked automatically
       // based on distance
       if (getAutonomyMode() != AutonomyMode.Smart) {
         drive.updateDesiredLocationFromNetworkTables(
             reefLocationSelector.get(), gamePieceSelector.get().equalsIgnoreCase("algae"));
-      }
 
-      // 20: left; 21: right
-      if (gamePieceSelector.get().equalsIgnoreCase("coral")) {
-        drive.setDesiredIntakeLocation(
-            intakeLocationSelector.get() == 20
-                ? DesiredLocation.CoralStationLeft
-                : DesiredLocation.CoralStationRight);
+        // 20: left; 21: right
+        if (gamePieceSelector.get().equalsIgnoreCase("coral")) {
+          drive.setDesiredIntakeLocation(
+              intakeLocationSelector.get() == 20
+                  ? DesiredLocation.CoralStationLeft
+                  : DesiredLocation.CoralStationRight);
+        }
       }
     }
 

--- a/src/main/java/frc/robot/StrategyManager.java
+++ b/src/main/java/frc/robot/StrategyManager.java
@@ -255,12 +255,14 @@ public class StrategyManager {
         scoringSubsystem.setGamePiece(GamePiece.Algae);
       }
 
-      // Don't automatically set level in smart mode; this will be set when the warmup trigger is
+      // Don't automatically set level in smart mode FOR ALGAE; this will be set when the warmup
+      // trigger is
       // pressed. This can't happen in periodic because algae level is automatically determined when
       // intake is pressed and would be overridden by this in each loop.
-      // if (getAutonomyMode() != AutonomyMode.Smart) {
-      scoringSubsystem.updateScoringLevelFromNetworkTables(reefLevelSelector.get());
-      // }
+      if (getAutonomyMode() != AutonomyMode.Smart
+          || scoringSubsystem.getGamePiece() != GamePiece.Algae) {
+        updateScoringLevelFromNetworkTables();
+      }
     }
 
     // update autonomy level
@@ -307,6 +309,10 @@ public class StrategyManager {
     // send and receive from SnakeScreen
     this.updateScoringLocationsFromSnakeScreen();
     this.publishCoralAndAlgae();
+  }
+
+  public void updateScoringLevelFromNetworkTables() {
+    scoringSubsystem.updateScoringLevelFromNetworkTables(reefLevelSelector.get());
   }
 
   public void publishDefaultSubsystemValues() {

--- a/src/main/java/frc/robot/subsystems/scoring/ClawIOSim.java
+++ b/src/main/java/frc/robot/subsystems/scoring/ClawIOSim.java
@@ -75,7 +75,7 @@ public class ClawIOSim implements ClawIO {
             .times(Seconds.of(0.02)));
 
     if (has == HasState.NONE) {
-      if (outputVoltage.in(Volts) > 0.0 && algaeAvailable) {
+      if (outputVoltage.in(Volts) < 0.0 && algaeAvailable) {
         has = HasState.ALGAE;
         piecePos = 1.0;
       }
@@ -90,8 +90,7 @@ public class ClawIOSim implements ClawIO {
                           * JsonConstants.clawConstantsSim.rotationsPerSecondPerVolt)
                   .times(Seconds.of(0.02))
                   .in(Rotations)
-              * 0.05
-              * (has == HasState.ALGAE ? -1.0 : 1.0);
+              * 0.05;
 
       if (piecePos > 1.0) {
         has = HasState.NONE;


### PR DESCRIPTION
- Don't update intake location from snakescreen when in smart mode; this is done when intake is pressed based on closest distance (closes #189)
- Update scoring level from snakescreen when warmup is pressed; this means you should be able to select reef level, instead of it being ignored like it was before (closes #187)