### PR TITLE
(#229) Decrease climb feedforwards

### DIFF
--- a/src/main/deploy/constants/comp/ClimbConstants.json
+++ b/src/main/deploy/constants/comp/ClimbConstants.json
@@ -21,7 +21,7 @@
   "climbInvertValue": "Clockwise_Positive",
   "invertFollowerClimbMotor": true,
   "climbFFVolts": -8.0,
-  "searchingFFVolts": 8.0,
+  "searchingFFVolts": 5.0,
   "searchingFFMargin": {
     "value": 0.0,
     "unit": "Radian"

--- a/src/main/deploy/constants/comp/ClimbConstants.json
+++ b/src/main/deploy/constants/comp/ClimbConstants.json
@@ -8,7 +8,7 @@
     "unit": "Radian"
   },
   "finalHangingAngle": {
-    "value": 0.6,
+    "value": 0.5,
     "unit": "Radian"
   },
   "climbEncoderOffsetRotations": -0.40234375,
@@ -20,8 +20,8 @@
   "climbCurrentLimit": 60.0,
   "climbInvertValue": "Clockwise_Positive",
   "invertFollowerClimbMotor": true,
-  "climbFFVolts": -8.0,
-  "searchingFFVolts": 5.0,
+  "climbFFVolts": -2.0,
+  "searchingFFVolts": 2.0,
   "searchingFFMargin": {
     "value": 0.0,
     "unit": "Radian"

--- a/src/main/deploy/constants/comp/ClimbConstants.json
+++ b/src/main/deploy/constants/comp/ClimbConstants.json
@@ -20,8 +20,8 @@
   "climbCurrentLimit": 60.0,
   "climbInvertValue": "Clockwise_Positive",
   "invertFollowerClimbMotor": true,
-  "climbFFVolts": -12.0,
-  "searchingFFVolts": 12.0,
+  "climbFFVolts": -8.0,
+  "searchingFFVolts": 8.0,
   "searchingFFMargin": {
     "value": 0.0,
     "unit": "Radian"

--- a/src/main/deploy/constants/comp/DrivetrainConstants.json
+++ b/src/main/deploy/constants/comp/DrivetrainConstants.json
@@ -75,7 +75,7 @@
       "ControlTimesyncFreqHz": 0.0
     },
     "CurrentLimits": {
-      "StatorCurrentLimit": 120.0,
+      "StatorCurrentLimit": 80.0,
       "StatorCurrentLimitEnable": true,
       "SupplyCurrentLimit": 70.0,
       "SupplyCurrentLimitEnable": true,

--- a/src/main/deploy/constants/comp/FeatureFlags.json
+++ b/src/main/deploy/constants/comp/FeatureFlags.json
@@ -2,6 +2,6 @@
   "runDrive": true,
   "runVision": true,
   "runScoring": true,
-  "runClimb": false,
+  "runClimb": true,
   "runRamp": true
 }

--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2025-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 81;
-  public static final String GIT_SHA = "3dec6a5746d20ff39b2dd422ccc65c3b139e00d6";
-  public static final String GIT_DATE = "2025-04-01 21:45:19 EDT";
-  public static final String GIT_BRANCH = "225-fix-linear-overshoot";
-  public static final String BUILD_DATE = "2025-04-01 21:47:52 EDT";
-  public static final long BUILD_UNIX_TIME = 1743558472426L;
+  public static final int GIT_REVISION = 76;
+  public static final String GIT_SHA = "2f2f1e23074508afe517286c263e6fb730fbf3ae";
+  public static final String GIT_DATE = "2025-04-02 08:49:38 EDT";
+  public static final String GIT_BRANCH = "229-lower-climb-ff";
+  public static final String BUILD_DATE = "2025-04-02 19:09:46 EDT";
+  public static final long BUILD_UNIX_TIME = 1743635386087L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}


### PR DESCRIPTION
Climb was moving way too fast after we fixed the climb jitter issues. Decreasing the feedforwards should stop it from unwinding or snapping the rope.